### PR TITLE
Do not require GITHUB_TOKEN for enterprise setups

### DIFF
--- a/selfupdate/updater.go
+++ b/selfupdate/updater.go
@@ -2,7 +2,6 @@ package selfupdate
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"os"
 
@@ -56,9 +55,6 @@ func NewUpdater(config Config) (*Updater, error) {
 		return &Updater{client, ctx}, nil
 	}
 
-	if token == "" {
-		return nil, errors.New("GitHub API token cannot be empty when releases are hosted on GitHub Enterprise instance")
-	}
 	u := config.EnterpriseUploadURL
 	if u == "" {
 		u = config.EnterpriseBaseURL

--- a/selfupdate/updater_test.go
+++ b/selfupdate/updater_test.go
@@ -61,16 +61,6 @@ func TestGitHubEnterpriseClient(t *testing.T) {
 	}
 }
 
-func TestGitHubEnterpriseClientWithoutToken(t *testing.T) {
-	token := os.Getenv("GITHUB_TOKEN")
-	defer os.Setenv("GITHUB_TOKEN", token)
-	os.Setenv("GITHUB_TOKEN", "")
-	_, err := NewUpdater(Config{EnterpriseBaseURL: "https://github.company.com/api/v3/"})
-	if err == nil {
-		t.Fatal("Error should be reported because of empty token")
-	}
-}
-
 func TestGitHubEnterpriseClientInvalidURL(t *testing.T) {
 	_, err := NewUpdater(Config{APIToken: "hogehoge", EnterpriseBaseURL: ":this is not a URL"})
 	if err == nil {


### PR DESCRIPTION
Not sure why this was added but using no token works for our GitHub enterprise installation.