### PR TITLE
Support gox naming pattern

### DIFF
--- a/selfupdate/uncompress.go
+++ b/selfupdate/uncompress.go
@@ -81,7 +81,8 @@ func UncompressCommand(src io.Reader, url, cmd string) (io.Reader, error) {
 		}
 
 		name := r.Header.Name
-		if name != cmd {
+		// Allow GOX name pattern of cmd_os_arch
+		if !strings.HasPrefix(name, cmd) {
 			return nil, fmt.Errorf("File name '%s' does not match to command '%s' found in %s", name, cmd, url)
 		}
 


### PR DESCRIPTION
As described at https://github.com/rhysd/go-github-selfupdate#naming-rules-of-released-binaries when pulling binaries out of .gzip files, don't require their names to be an exact match. Just checking the prefix seems reasonable.

Otherwise I have to symlink foo to foo_darwin_amd64 for the binary to self-update.