### PR TITLE
FIX: compile errors

### DIFF
--- a/selfupdate/detect.go
+++ b/selfupdate/detect.go
@@ -69,7 +69,7 @@ func findAssetFromRelease(rel *github.RepositoryRelease,
 		for _, s := range suffixes {
 			if strings.HasSuffix(name, s) { // require version, arch etc
 				// default: assume single artifact
-				return &asset, ver, true
+				return asset, ver, true
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func findAssetFromRelease(rel *github.RepositoryRelease,
 func findValidationAsset(rel *github.RepositoryRelease, validationName string) (*github.ReleaseAsset, bool) {
 	for _, asset := range rel.Assets {
 		if asset.GetName() == validationName {
-			return &asset, true
+			return asset, true
 		}
 	}
 	return nil, false

--- a/selfupdate/update.go
+++ b/selfupdate/update.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/inconshreveable/go-update"
+	update "github.com/inconshreveable/go-update"
 )
 
 func uncompressAndUpdate(src io.Reader, assetURL, cmdPath string) error {
@@ -56,7 +56,8 @@ func (up *Updater) downloadDirectlyFromURL(assetURL string) (io.ReadCloser, erro
 // It downloads a release asset via GitHub Releases API so this function is available for update releases on private repository.
 // If a redirect occurs, it fallbacks into directly downloading from the redirect URL.
 func (up *Updater) UpdateTo(rel *Release, cmdPath string) error {
-	src, redirectURL, err := up.api.Repositories.DownloadReleaseAsset(up.apiCtx, rel.RepoOwner, rel.RepoName, rel.AssetID)
+	var client http.Client
+	src, redirectURL, err := up.api.Repositories.DownloadReleaseAsset(up.apiCtx, rel.RepoOwner, rel.RepoName, rel.AssetID, &client)
 	if err != nil {
 		return fmt.Errorf("Failed to call GitHub Releases API for getting an asset(ID: %d) for repository '%s/%s': %s", rel.AssetID, rel.RepoOwner, rel.RepoName, err)
 	}
@@ -78,7 +79,7 @@ func (up *Updater) UpdateTo(rel *Release, cmdPath string) error {
 		return uncompressAndUpdate(bytes.NewReader(data), rel.AssetURL, cmdPath)
 	}
 
-	validationSrc, validationRedirectURL, err := up.api.Repositories.DownloadReleaseAsset(up.apiCtx, rel.RepoOwner, rel.RepoName, rel.ValidationAssetID)
+	validationSrc, validationRedirectURL, err := up.api.Repositories.DownloadReleaseAsset(up.apiCtx, rel.RepoOwner, rel.RepoName, rel.ValidationAssetID, &client)
 	if err != nil {
 		return fmt.Errorf("Failed to call GitHub Releases API for getting an validation asset(ID: %d) for repository '%s/%s': %s", rel.ValidationAssetID, rel.RepoOwner, rel.RepoName, err)
 	}


### PR DESCRIPTION
For some reason, I got compile-time errors while trying to use your library. 

> /home/qu_zh/go/src/github.com/rhysd/go-github-selfupdate/selfupdate/detect.go:72:12: cannot use &asset (type **github.ReleaseAsset) as type *github.ReleaseAsset in return argument
/home/qu_zh/go/src/github.com/rhysd/go-github-selfupdate/selfupdate/detect.go:84:11: cannot use &asset (type **github.ReleaseAsset) as type *github.ReleaseAsset in return argument
/home/qu_zh/go/src/github.com/rhysd/go-github-selfupdate/selfupdate/update.go:59:67: not enough arguments in call to up.api.Repositories.DownloadReleaseAsset
        have (context.Context, string, string, int64)
        want (context.Context, string, string, int64, *http.Client)
/home/qu_zh/go/src/github.com/rhysd/go-github-selfupdate/selfupdate/update.go:81:87: not enough arguments in call to up.api.Repositories.DownloadReleaseAsset
        have (context.Context, string, string, int64)
        want (context.Context, string, string, int64, *http.Client)

To see the error by yourself:

```sh
go get -u github.com/rhysd/go-github-selfupdate/cmd/selfupdate-example
```

With this PR, I can happily use it again. 
