### PR TITLE
Allow to change GOARCH before updating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/creativeprojects/go-github-selfupdate
+module github.com/rhysd/go-github-selfupdate
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rhysd/go-github-selfupdate
+module github.com/creativeprojects/go-github-selfupdate
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/selfupdate/arch.go
+++ b/selfupdate/arch.go
@@ -1,0 +1,24 @@
+package selfupdate
+
+import "runtime"
+
+var (
+	useOS   = runtime.GOOS
+	useArch = runtime.GOARCH
+)
+
+// SetArch forces the use of a different architecture than the default runtime.GOARCH
+//
+// For example SetArch("arm_v6") instead of the default "arm"
+func SetArch(arch string) {
+	if arch == "" {
+		// Back to the default
+		arch = runtime.GOARCH
+	}
+	useArch = arch
+}
+
+// GetOSArch returns the OS and Architecture currently used to detect a new version
+func GetOSArch() (string, string) {
+	return useOS, useArch
+}

--- a/selfupdate/arch_test.go
+++ b/selfupdate/arch_test.go
@@ -1,0 +1,33 @@
+package selfupdate
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDefaultOSAndArch(t *testing.T) {
+	os, arch := GetOSArch()
+	if os != runtime.GOOS {
+		t.Errorf("OS should be %s but found %s", runtime.GOOS, os)
+	}
+	if arch != runtime.GOARCH {
+		t.Errorf("Arch should be %s but found %s", runtime.GOARCH, arch)
+	}
+}
+
+func TestForcesArch(t *testing.T) {
+	testArch := "test"
+	SetArch(testArch)
+	_, arch := GetOSArch()
+
+	if arch != testArch {
+		t.Errorf("Arch should be %s but found %s", testArch, arch)
+	}
+
+	SetArch("")
+	_, arch = GetOSArch()
+
+	if arch != runtime.GOARCH {
+		t.Errorf("Arch should be %s but found %s", runtime.GOARCH, arch)
+	}
+}

--- a/selfupdate/detect.go
+++ b/selfupdate/detect.go
@@ -3,7 +3,6 @@ package selfupdate
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
@@ -94,10 +93,10 @@ func findReleaseAndAsset(rels []*github.RepositoryRelease,
 	suffixes := make([]string, 0, 2*7*2)
 	for _, sep := range []rune{'_', '-'} {
 		for _, ext := range []string{".zip", ".tar.gz", ".tgz", ".gzip", ".gz", ".tar.xz", ".xz", ""} {
-			suffix := fmt.Sprintf("%s%c%s%s", runtime.GOOS, sep, runtime.GOARCH, ext)
+			suffix := fmt.Sprintf("%s%c%s%s", useOS, sep, useArch, ext)
 			suffixes = append(suffixes, suffix)
-			if runtime.GOOS == "windows" {
-				suffix = fmt.Sprintf("%s%c%s.exe%s", runtime.GOOS, sep, runtime.GOARCH, ext)
+			if useOS == "windows" {
+				suffix = fmt.Sprintf("%s%c%s.exe%s", useOS, sep, useArch, ext)
 				suffixes = append(suffixes, suffix)
 			}
 		}
@@ -123,7 +122,7 @@ func findReleaseAndAsset(rels []*github.RepositoryRelease,
 	}
 
 	if release == nil {
-		log.Println("Could not find any release for", runtime.GOOS, "and", runtime.GOARCH)
+		log.Println("Could not find any release for", useOS, "and", useArch)
 		return nil, nil, semver.Version{}, false
 	}
 

--- a/selfupdate/uncompress.go
+++ b/selfupdate/uncompress.go
@@ -6,12 +6,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"github.com/ulikunitz/xz"
 	"io"
 	"io/ioutil"
 	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/ulikunitz/xz"
 )
 
 func matchExecutableName(cmd, target string) bool {
@@ -19,7 +19,7 @@ func matchExecutableName(cmd, target string) bool {
 		return true
 	}
 
-	o, a := runtime.GOOS, runtime.GOARCH
+	o, a := GetOSArch()
 
 	// When the contained executable name is full name (e.g. foo_darwin_amd64),
 	// it is also regarded as a target executable file. (#19)

--- a/selfupdate/update.go
+++ b/selfupdate/update.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
@@ -108,7 +107,7 @@ func (up *Updater) UpdateTo(rel *Release, cmdPath string) error {
 // UpdateCommand updates a given command binary to the latest version.
 // 'slug' represents 'owner/name' repository on GitHub and 'current' means the current version.
 func (up *Updater) UpdateCommand(cmdPath string, current semver.Version, slug string) (*Release, error) {
-	if runtime.GOOS == "windows" && !strings.HasSuffix(cmdPath, ".exe") {
+	if useOS == "windows" && !strings.HasSuffix(cmdPath, ".exe") {
 		// Ensure to add '.exe' to given path on Windows
 		cmdPath = cmdPath + ".exe"
 	}


### PR DESCRIPTION
Hi,

This is a very simple code change that allow to change the default runtime.GOARCH.

It introduces a package variable initialized with runtime.GOARCH, which we can override by `SetArch("other")`.

This change does not introduce any code to try to detect the right architecture in some cases (that's only for GOARCH=arm as far as I know)

Fixes https://github.com/rhysd/go-github-selfupdate/issues/32
