### PR TITLE
Allow updating to draft and pre-release

### DIFF
--- a/selfupdate/detect_test.go
+++ b/selfupdate/detect_test.go
@@ -434,7 +434,7 @@ func TestFindReleaseAndAsset(t *testing.T) {
 			expectedFound: false,
 		},
 	} {
-		asset, ver, found := findAssetFromRelease(fixture.rels, []string{".gz"}, fixture.targetVersion, fixture.filters)
+		asset, ver, found := findAssetFromRelease(fixture.rels, []string{".gz"}, fixture.targetVersion, fixture.filters, options{})
 		if fixture.expectedFound {
 			if !found {
 				t.Errorf("expected to find an asset for this fixture: %q", fixture.name)

--- a/selfupdate/release.go
+++ b/selfupdate/release.go
@@ -10,6 +10,10 @@ import (
 type Release struct {
 	// Version is the version of the release
 	Version semver.Version
+	// PreRelease is the pre-release flag of the release
+	PreRelease bool
+	// Draft is the draft flag of the release
+	Draft bool
 	// AssetURL is a URL to the uploaded file for the release
 	AssetURL string
 	// AssetSize represents the size of asset in bytes

--- a/selfupdate/updater.go
+++ b/selfupdate/updater.go
@@ -19,6 +19,8 @@ type Updater struct {
 	apiCtx    context.Context
 	validator Validator
 	filters   []*regexp.Regexp
+	pre       bool
+	draft     bool
 }
 
 // Config represents the configuration of self-update.
@@ -37,6 +39,10 @@ type Config struct {
 	// An asset is selected if it matches any of those, in addition to the regular tag, os, arch, extensions.
 	// Please make sure that your filter(s) uniquely match an asset.
 	Filters []string
+	// PreRelease indicates if pre-releases are allowed.
+	PreRelease bool
+	// Draft indicates if drafts are allowed.
+	Draft bool
 }
 
 func newHTTPClient(ctx context.Context, token string) *http.Client {
@@ -71,7 +77,7 @@ func NewUpdater(config Config) (*Updater, error) {
 
 	if config.EnterpriseBaseURL == "" {
 		client := github.NewClient(hc)
-		return &Updater{api: client, apiCtx: ctx, validator: config.Validator, filters: filtersRe}, nil
+		return &Updater{api: client, apiCtx: ctx, validator: config.Validator, filters: filtersRe, pre: config.PreRelease, draft: config.Draft}, nil
 	}
 
 	u := config.EnterpriseUploadURL
@@ -82,7 +88,7 @@ func NewUpdater(config Config) (*Updater, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Updater{api: client, apiCtx: ctx, validator: config.Validator, filters: filtersRe}, nil
+	return &Updater{api: client, apiCtx: ctx, validator: config.Validator, filters: filtersRe, pre: config.PreRelease, draft: config.Draft}, nil
 }
 
 // DefaultUpdater creates a new updater instance with default configuration.


### PR DESCRIPTION
New fields are added to update to draft and pre-release versions.
Fixes rhysd/go-github-selfupdate#14