### PR TITLE
Add NoGitUpdater

### DIFF
--- a/selfupdate/updater.go
+++ b/selfupdate/updater.go
@@ -97,3 +97,12 @@ func DefaultUpdater() *Updater {
 	client := newHTTPClient(ctx, token)
 	return &Updater{api: github.NewClient(client), apiCtx: ctx}
 }
+
+// NoGitUpdater is like DefaultUpdater but doesn't launch `git` to query
+// for your GitHub token if not provided
+func NoGitUpdater() *Updater {
+	token := os.Getenv("GITHUB_TOKEN")
+	ctx := context.Background()
+	client := newHTTPClient(ctx, token)
+	return &Updater{api: github.NewClient(client), apiCtx: ctx}
+}


### PR DESCRIPTION
The `DefaultUpdater` uses the `gitconfig` pkg to query for the `github.token` setting in `git`. It does this by launching `git`, and when used in a Windows GUI app, this causes console windows to appear.

This PR adds a `NoGitUpdater` which is the same as `DefaultUpdater` but skips the `gitconfig` check 