### PR TITLE
fix: add masOS as popular suffix replacement in goreleaser

### DIFF
--- a/selfupdate/detect.go
+++ b/selfupdate/detect.go
@@ -100,6 +100,9 @@ func findReleaseAndAsset(rels []*github.RepositoryRelease,
 				suffix = fmt.Sprintf("%s%c%s.exe%s", runtime.GOOS, sep, runtime.GOARCH, ext)
 				suffixes = append(suffixes, suffix)
 			}
+			if runtime.GOOS == "darwin" {
+				suffixes = append(suffixes, fmt.Sprintf("%s%c%s%s", "macOS", sep, runtime.GOARCH, ext))
+			}
 		}
 	}
 


### PR DESCRIPTION
Darwin is not popular name most of the repositories use macOS as name of the binary (that is even documented in goreleaser repository). This change doesn't affect any existing code. It just adds one extra suffix.