### PR TITLE
fix: resolving README typo for the UpdateTo parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ func confirmAndSelfUpdate() {
         log.Println("Could not locate executable path")
         return
     }
-    if err := selfupdate.UpdateTo(latest.AssetURL, exe); err != nil {
+    if err := selfupdate.UpdateTo(latest, exe); err != nil {
         log.Println("Error occurred while updating binary:", err)
         return
     }


### PR DESCRIPTION
**What does this PR do?**

Just resolves a minor issue with the README. In it's old state the README displayed UpdateTo(latest.AssetURL, ...) which is a string rather than the expected *Release value per https://pkg.go.dev/github.com/rhysd/go-github-selfupdate/selfupdate#Updater.UpdateTo 